### PR TITLE
Added Client.snapshotVersion(), replaced snapshot() for security matters

### DIFF
--- a/src/client.d.ts
+++ b/src/client.d.ts
@@ -117,6 +117,11 @@ export class Client {
    */
   static testMode(testEnabled?: boolean): void;
 
+  /**
+   * Returns the current snapshot version
+   */
+  static get snapshotVersion(): number
+
 }
 
 /**

--- a/src/client.js
+++ b/src/client.js
@@ -254,6 +254,10 @@ export class Client {
   static testMode(testEnabled = true) {
     Client.testEnabled = testEnabled;
   }
+
+  static get snapshotVersion() {
+    return GlobalSnapshot.snapshot?.data.domain.version || 0;
+  }
 }
 
 // Type export placeholders

--- a/tests/switcher-functional.test.js
+++ b/tests/switcher-functional.test.js
@@ -320,10 +320,10 @@ describe('Integrated test - Switcher:', function () {
     });
 
     it('should use silent mode when fail to check switchers', async function() {
-      //given
+      // given
       given(fetchStub, 0, { status: 429 });
 
-      //test
+      // test
       Client.buildContext(contextSettings, { silentMode: '5m', regexSafe: false, snapshotLocation: './tests/snapshot/' });
       await Client.checkSwitchers(['FEATURE01', 'FEATURE02']).catch(e => {
         assert.equal(e.message, 'Something went wrong: [FEATURE01,FEATURE02] not found');
@@ -400,45 +400,45 @@ describe('Integrated test - Switcher:', function () {
     });
 
     it('should NOT throw when switcher keys provided were configured properly', async function() {
-      //given
+      // given
       given(fetchStub, 0, { json: () => generateAuth('[auth_token]', 5), status: 200 });
       const response = { not_found: [] };
       given(fetchStub, 1, { json: () => response, status: 200 });
 
-      //test
+      // test
       Client.buildContext(contextSettings);
       await assertResolve(assert, Client.checkSwitchers(['FEATURE01', 'FEATURE02']));
     });
 
     it('should throw when switcher keys provided were not configured properly', async function() {
-      //given
+      // given
       given(fetchStub, 0, { json: () => generateAuth('[auth_token]', 5), status: 200 });
       const response = { not_found: ['FEATURE02'] };
       given(fetchStub, 1, { json: () => response, status: 200 });
 
-      //test
+      // test
       Client.buildContext(contextSettings);
       await assertReject(assert, Client.checkSwitchers(['FEATURE01', 'FEATURE02']), 
         'Something went wrong: [FEATURE02] not found');
     });
 
     it('should throw when no switcher keys were provided', async function() {
-      //given
+      // given
       given(fetchStub, 0, { json: () => generateAuth('[auth_token]', 5), status: 200 });
       given(fetchStub, 1, { status: 422 });
 
-      //test
+      // test
       Client.buildContext(contextSettings);
       await assertReject(assert, Client.checkSwitchers([]), 
         'Something went wrong: [checkSwitchers] failed with status 422');
     });
 
     it('should throw when switcher keys provided were invalid', async function() {
-      //given
+      // given
       given(fetchStub, 0, { json: () => generateAuth('[auth_token]', 5), status: 200 });
       given(fetchStub, 1, { errno: 'ERROR' });
 
-      //test
+      // test
       Client.buildContext(contextSettings);
       await assertReject(assert, Client.checkSwitchers('FEATURE02'), 
         'Something went wrong: [checkSwitchers] failed with status undefined');

--- a/tests/switcher-snapshot.test.js
+++ b/tests/switcher-snapshot.test.js
@@ -43,37 +43,35 @@ describe('E2E test - Switcher local - Snapshot:', function () {
   });
 
   it('should update snapshot', async function () {
-    //given
+    // given
     fetchStub = stub(FetchFacade, 'fetch');
 
     given(fetchStub, 0, { json: () => generateAuth('[auth_token]', 5), status: 200 });
     given(fetchStub, 1, { json: () => generateStatus(false), status: 200 }); // Snapshot outdated
     given(fetchStub, 2, { json: () => JSON.parse(dataJSON), status: 200 });
 
-    //test
+    // test
     Client.buildContext({ url, apiKey, domain, component, environment }, {
-      snapshotLocation: 'generated-snapshots/',
       local: true,
       regexSafe: false
     });
     
     await Client.loadSnapshot({ watchSnapshot: true });
-    assert.isTrue(await Client.checkSnapshot());
 
-    //restore state to avoid process leakage
-    Client.unloadSnapshot();
-    unlinkSync(`generated-snapshots/${environment}.json`);
+    assert.equal(Client.snapshotVersion, 0);
+    assert.isTrue(await Client.checkSnapshot());
+    assert.isAbove(Client.snapshotVersion, 0);
   });
 
   it('should update snapshot - store file', async function () {
-    //given
+    // given
     fetchStub = stub(FetchFacade, 'fetch');
 
     given(fetchStub, 0, { json: () => generateAuth('[auth_token]', 5), status: 200 });
     given(fetchStub, 1, { json: () => generateStatus(false), status: 200 }); // Snapshot outdated
     given(fetchStub, 2, { json: () => JSON.parse(dataJSON), status: 200 });
 
-    //test
+    // test
     Client.buildContext({ url, apiKey, domain, component, environment }, {
       snapshotLocation: 'generated-snapshots/',
       local: true,
@@ -84,19 +82,19 @@ describe('E2E test - Switcher local - Snapshot:', function () {
     assert.isTrue(await Client.checkSnapshot());
     assert.isTrue(existsSync(`generated-snapshots/${environment}.json`));
 
-    //restore state to avoid process leakage
+    // restore state to avoid process leakage
     Client.unloadSnapshot();
   });
 
   it('should update snapshot during load - store file', async function () {
-    //given
+    // given
     fetchStub = stub(FetchFacade, 'fetch');
 
     given(fetchStub, 0, { json: () => generateAuth('[auth_token]', 5), status: 200 });
     given(fetchStub, 1, { json: () => generateStatus(false), status: 200 }); // Snapshot outdated
     given(fetchStub, 2, { json: () => JSON.parse(dataJSON), status: 200 });
 
-    //test
+    // test
     Client.buildContext({ url, apiKey, domain, component, environment }, {
       snapshotLocation: 'generated-snapshots/',
       local: true,
@@ -106,18 +104,18 @@ describe('E2E test - Switcher local - Snapshot:', function () {
     await Client.loadSnapshot({ watchSnapshot: true, fetchRemote: true });
     assert.isTrue(existsSync(`generated-snapshots/${environment}.json`));
 
-    //restore state to avoid process leakage
+    // restore state to avoid process leakage
     Client.unloadSnapshot();
   });
 
   it('should NOT update snapshot', async function () {
-    //given
+    // given
     fetchStub = stub(FetchFacade, 'fetch');
 
     given(fetchStub, 0, { json: () => generateAuth('[auth_token]', 5), status: 200 });
     given(fetchStub, 1, { json: () => generateStatus(true), status: 200 }); // No available update
     
-    //test
+    // test
     await Client.loadSnapshot();
     assert.isFalse(await Client.checkSnapshot());
   });
@@ -125,13 +123,13 @@ describe('E2E test - Switcher local - Snapshot:', function () {
   it('should NOT update snapshot - check Snapshot Error', async function () {
     this.timeout(3000);
 
-    //given
+    // given
     fetchStub = stub(FetchFacade, 'fetch');
 
     given(fetchStub, 0, { json: () => generateAuth('[auth_token]', 5), status: 200 });
     givenError(fetchStub, 1, { errno: 'ECONNREFUSED' });
     
-    //test
+    // test
     Client.testMode();
     await Client.loadSnapshot();
     await assertReject(assert, Client.checkSnapshot(), 
@@ -139,14 +137,14 @@ describe('E2E test - Switcher local - Snapshot:', function () {
   });
 
   it('should NOT update snapshot - resolve Snapshot Error', async function () {
-    //given
+    // given
     fetchStub = stub(FetchFacade, 'fetch');
 
     given(fetchStub, 0, { json: () => generateAuth('[auth_token]', 5), status: 200 });
     given(fetchStub, 1, { json: () => generateStatus(false), status: 200 }); // Snapshot outdated
     givenError(fetchStub, 2, { errno: 'ECONNREFUSED' });
     
-    //test
+    // test
     Client.testMode();
     await Client.loadSnapshot();
     await assertReject(assert, Client.checkSnapshot(), 
@@ -154,21 +152,21 @@ describe('E2E test - Switcher local - Snapshot:', function () {
   });
 
   it('should NOT check snapshot with success - Snapshot not loaded', async function () {
-    //given
+    // given
     fetchStub = stub(FetchFacade, 'fetch');
 
     given(fetchStub, 0, { json: () => generateAuth('[auth_token]', 5), status: 200 });
     given(fetchStub, 1, { json: () => generateStatus(true), status: 200 });
     
-    //pre-load snapshot
+    // pre-load snapshot
     Client.testMode(false);
     await Client.loadSnapshot();
     assert.equal(await Client.checkSnapshot(), false);
 
-    //unload snapshot
+    // unload snapshot
     Client.unloadSnapshot();
     
-    //test
+    // test
     let error = null;
     await Client.checkSnapshot().catch((err) => error = err);
     assert.exists(error);
@@ -176,14 +174,14 @@ describe('E2E test - Switcher local - Snapshot:', function () {
   });
 
   it('should update snapshot', async function () {
-    //given
+    // given
     fetchStub = stub(FetchFacade, 'fetch');
 
     given(fetchStub, 0, { json: () => generateAuth('[auth_token]', 5), status: 200 });
     given(fetchStub, 1, { json: () => generateStatus(false), status: 200 }); // Snapshot outdated
     given(fetchStub, 2, { json: () => JSON.parse(dataJSON), status: 200 });
 
-    //test
+    // test
     Client.buildContext({ url, apiKey, domain, component, environment }, {
       snapshotLocation: 'generated-snapshots/'
     });
@@ -191,7 +189,7 @@ describe('E2E test - Switcher local - Snapshot:', function () {
     await Client.loadSnapshot();
     assert.isNotNull(Client.snapshot);
 
-    //restore state to avoid process leakage
+    // restore state to avoid process leakage
     Client.unloadSnapshot();
     unlinkSync(`generated-snapshots/${environment}.json`);
   });
@@ -234,13 +232,13 @@ describe('E2E test - Fail response - Snapshot:', function () {
   });
 
   it('should NOT update snapshot - Too many requests at checkSnapshotVersion', async function () {
-    //given
+    // given
     fetchStub = stub(FetchFacade, 'fetch');
 
     given(fetchStub, 0, { json: () => generateAuth('[auth_token]', 5), status: 200 });
     given(fetchStub, 1, { status: 429 });
     
-    //test
+    // test
     Client.testMode();
     await Client.loadSnapshot();
     await assertReject(assert, Client.checkSnapshot(),
@@ -248,14 +246,14 @@ describe('E2E test - Fail response - Snapshot:', function () {
   });
 
   it('should NOT update snapshot - Too many requests at resolveSnapshot', async function () {
-    //given
+    // given
     fetchStub = stub(FetchFacade, 'fetch');
 
     given(fetchStub, 0, { json: () => generateAuth('[auth_token]', 5), status: 200 });
     given(fetchStub, 1, { json: () => generateStatus(false), status: 200 }); // Snapshot outdated
     given(fetchStub, 2, { status: 429 });
 
-    //test
+    // test
     Client.buildContext({ url, apiKey, domain, component, environment }, {
       snapshotLocation: 'generated-snapshots/',
       regexSafe: false
@@ -299,7 +297,7 @@ describe('E2E test - Snapshot AutoUpdater:', function () {
   it('should auto update snapshot every second', async function () {
     this.timeout(3000);
 
-    //given
+    // given
     fetchStub = stub(FetchFacade, 'fetch');
 
     given(fetchStub, 0, { json: () => generateAuth('[auth_token]', 5), status: 200 });
@@ -308,7 +306,7 @@ describe('E2E test - Snapshot AutoUpdater:', function () {
     given(fetchStub, 3, { json: () => generateStatus(false), status: 200 }); // Loading updated version
     given(fetchStub, 4, { json: () => JSON.parse(dataJSONV2), status: 200 });
 
-    //test
+    // test
     Client.buildContext({ url, apiKey, domain, component, environment }, {
       snapshotLocation: 'generated-snapshots/',
       local: true,
@@ -336,12 +334,12 @@ describe('E2E test - Snapshot AutoUpdater:', function () {
     this.timeout(3000);
     fetchStub = stub(FetchFacade, 'fetch');
 
-    //given
+    // given
     given(fetchStub, 0, { json: () => generateAuth('[auth_token]', 5), status: 200 });
     given(fetchStub, 1, { json: () => generateStatus(false), status: 200 });
     given(fetchStub, 2, { json: () => JSON.parse(dataJSON), status: 200 });
 
-    //test
+    // test
     Client.buildContext({ url, apiKey, domain, component, environment }, {
       local: true,
       regexSafe: false
@@ -354,7 +352,7 @@ describe('E2E test - Snapshot AutoUpdater:', function () {
     
     await Client.loadSnapshot({ watchSnapshot: false, fetchRemote: true });
 
-    //next call will fail
+    // next call will fail
     givenError(fetchStub, 3, { errno: 'ECONNREFUSED' });
     
     await sleep(1000);
@@ -362,7 +360,7 @@ describe('E2E test - Snapshot AutoUpdater:', function () {
     assert.exists(error);
     assert.equal(error.message, 'Something went wrong: Connection has been refused - ECONNREFUSED');
 
-    //tearDown
+    // tearDown
     Client.terminateSnapshotAutoUpdate();
   });
 


### PR DESCRIPTION
### Enhancements to snapshot handling:

* **`src/client.js`**: Added a new static method `snapshotVersion` to the `Client` class to retrieve the snapshot version from `GlobalSnapshot`. This method returns the version or defaults to `0` if no snapshot data is available.
This API replaces the old `Client.snapshot()`, which could leak sensitive data from Strategy values. The snapshot version can be used to log or validate latest changes in runtime.
