### PR TITLE
chore: moved snapshotWatcher from client to lib

### DIFF
--- a/src/lib/snapshotWatcher.js
+++ b/src/lib/snapshotWatcher.js
@@ -1,0 +1,38 @@
+import { watchFile, unwatchFile } from 'node:fs';
+import { GlobalOptions } from './globals/globalOptions.js';
+import { GlobalSnapshot } from './globals/globalSnapshot.js';
+import { loadDomain } from './snapshot.js';
+
+/**
+ * SnapshotWatcher is a utility class that watches for changes in the snapshot file
+ * and triggers a callback when the file is modified.
+ */
+export class SnapshotWatcher {
+  #snapshotFile;
+
+  watchSnapshot(environment, callback = {}) {
+    const { success = () => { }, reject = () => { } } = callback;
+    
+    this.#snapshotFile = `${GlobalOptions.snapshotLocation}/${environment}.json`;
+    let lastUpdate;
+    watchFile(this.#snapshotFile, (listener) => {
+      try {
+        if (!lastUpdate || listener.ctime > lastUpdate) {
+          GlobalSnapshot.init(loadDomain(GlobalOptions.snapshotLocation, environment));
+          success();
+        }
+      } catch (e) {
+        reject(e);
+      } finally {
+        lastUpdate = listener.ctime;
+      }
+    });
+  }
+
+  stopWatching() {
+    if (this.#snapshotFile) {
+      unwatchFile(this.#snapshotFile);
+      this.#snapshotFile = undefined;
+    }
+  }
+}

--- a/tests/playground/index.js
+++ b/tests/playground/index.js
@@ -26,11 +26,11 @@ async function setupSwitcher(local) {
  * Snapshot is loaded from file at tests/playground/snapshot/local.json
  */
 const _testLocal = async () => {
-    Client.buildContext({ 
-        domain: 'Local Playground', 
-        environment: 'local' 
-    }, { 
-        snapshotLocation: './tests/playground/snapshot/', 
+    Client.buildContext({
+        domain: 'Local Playground',
+        environment: 'local'
+    }, {
+        snapshotLocation: './tests/playground/snapshot/',
         local: true
     });
 
@@ -39,7 +39,7 @@ const _testLocal = async () => {
         .catch(() => console.log('Failed to load Snapshot'));
 
     const switcher = Client.getSwitcher(SWITCHER_KEY)
-            .detail();
+        .detail();
 
     setInterval(() => {
         const time = Date.now();
@@ -52,7 +52,7 @@ const _testLocal = async () => {
 // Requires remote API
 const _testSimpleAPICall = async (local) => {
     await setupSwitcher(local);
-    
+
     await Client.checkSwitchers([SWITCHER_KEY])
         .then(() => console.log('Switcher checked'))
         .catch(error => console.log(error));
@@ -69,7 +69,7 @@ const _testSimpleAPICall = async (local) => {
 // Requires remote API
 const _testThrottledAPICall = async () => {
     setupSwitcher(false);
-    
+
     await Client.checkSwitchers([SWITCHER_KEY]);
     Client.subscribeNotifyError((error) => console.log(error));
 
@@ -81,7 +81,7 @@ const _testThrottledAPICall = async () => {
         const result = await switcher
             .detail()
             .isItOn(SWITCHER_KEY);
-            
+
         console.log(`- ${Date.now() - time} ms - ${JSON.stringify(result)}`);
     }, 1000);
 };
@@ -90,7 +90,7 @@ const _testThrottledAPICall = async () => {
 const _testSnapshotUpdate = async () => {
     setupSwitcher(false);
     await sleep(2000);
-    
+
     console.log('checkSnapshot:', await Client.checkSnapshot());
 };
 
@@ -148,18 +148,18 @@ const _testWatchSnapshot = async () => {
 };
 
 // Does not require remote API
-const _testWatchSnapshotContextOptions  = async () => {
-    Client.buildContext({ domain, environment }, { 
+const _testWatchSnapshotContextOptions = async () => {
+    Client.buildContext({ domain, environment }, {
         snapshotLocation,
         snapshotWatcher: true,
-        local: true, 
+        local: true,
         logger: true
     });
 
     await Client.loadSnapshot();
 
     const switcher = Client.getSwitcher();
-    
+
     setInterval(async () => {
         const time = Date.now();
         const result = await switcher
@@ -172,7 +172,7 @@ const _testWatchSnapshotContextOptions  = async () => {
 
 // Requires remote API
 const _testSnapshotAutoUpdate = async () => {
-    Client.buildContext({ url, apiKey, domain, component, environment }, 
+    Client.buildContext({ url, apiKey, domain, component, environment },
         { local: true, logger: true });
 
     await Client.loadSnapshot({ watchSnapshot: false, fetchRemote: true });
@@ -191,4 +191,4 @@ const _testSnapshotAutoUpdate = async () => {
     }, 2000);
 };
 
-_testWatchSnapshot();
+_testLocal();


### PR DESCRIPTION
This pull request refactors the snapshot-watching functionality in the `Client` class by introducing a new `SnapshotWatcher` utility class. It also improves encapsulation by converting the `testEnabled` property to a private static field and updates the testing code to use a local test method. These changes enhance modularity, maintainability, and clarity of the codebase.

### Refactoring Snapshot-Watching Functionality:
* Introduced `SnapshotWatcher` class in `src/lib/snapshotWatcher.js` to encapsulate snapshot-watching logic, replacing the direct use of `watchFile` and `unwatchFile` in the `Client` class.
* Updated `Client.watchSnapshot` and `Client.unloadSnapshot` methods to delegate snapshot-watching operations to the new `SnapshotWatcher` class.

### Encapsulation Improvements:
* Converted `Client.testEnabled` to a private static field `Client.#testEnabled` for better encapsulation and consistency. Updated all references accordingly. [[1]](diffhunk://#diff-627fe08d8bba6a4fa76e7c5ed36ef6f16d126733e65e19236b391de0d34f1fe0R25-R34) [[2]](diffhunk://#diff-627fe08d8bba6a4fa76e7c5ed36ef6f16d126733e65e19236b391de0d34f1fe0L265-R255)

### Testing Updates:
* Modified the test code in `tests/playground/index.js` to call `_testLocal()` instead of `_testWatchSnapshot()`.