### PR TITLE
feat: added flushExecutions to clear cached results

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,15 @@ Client.subscribeNotifyError((error) => {
 });
 ```
 
+#### Flush cached results from throttling
+
+When using throttling, you can clear cached results for a specific switcher:
+
+```js
+// Clear cached results for a specific switcher
+Client.getSwitcher('FEATURE01').flushExecutions();
+```
+
 ### Hybrid Mode
 
 Force specific switchers to resolve remotely while running in local mode. Ideal for features requiring remote validation (e.g., Relay Strategies):

--- a/src/lib/utils/executionLogger.js
+++ b/src/lib/utils/executionLogger.js
@@ -65,6 +65,17 @@ export default class ExecutionLogger {
     }
 
     /**
+     * Clear results by switcher key
+     */
+    static clearByKey(key) {
+        for (let index = logger.length - 1; index >= 0; index--) {
+            if (logger[index].key === key) {
+                logger.splice(index, 1);
+            }
+        }
+    }
+
+    /**
      * Subscribe to error notifications
      */
     static subscribeNotifyError(callbackError) {

--- a/src/switcher.d.ts
+++ b/src/switcher.d.ts
@@ -127,6 +127,11 @@ export class Switcher {
   throttle(delay: number): Switcher;
 
   /**
+   * Flush cached executions for the current switcher key
+   */
+  flushExecutions(): void;
+  
+  /**
    * Force the use of the remote API when local is enabled
    */
   remote(forceRemote?: boolean): Switcher;

--- a/src/switcher.js
+++ b/src/switcher.js
@@ -140,6 +140,10 @@ export class Switcher extends SwitcherRequest {
     }
   }
 
+  flushExecutions() {
+    ExecutionLogger.clearByKey(this._key);
+  }
+
   #notifyError(err) {
     ExecutionLogger.notifyError(err);
   }

--- a/tests/playground/index.js
+++ b/tests/playground/index.js
@@ -95,14 +95,14 @@ const _testSnapshotUpdate = async () => {
     console.log('checkSnapshot:', await Client.checkSnapshot());
 };
 
-// Requires remote API
+// Does not require remote API
 const _testAsyncCall = async () => {
-    setupSwitcher(false);
+    setupSwitcher(true);
     const switcher = Client.getSwitcher(SWITCHER_KEY);
 
-    console.log('Sync:', await switcher.isItOn());
+    console.log('Sync:', await switcher.isItOnBool(true));
 
-    switcher.isItOn()
+    switcher.isItOnBool(true)
         .then(res => console.log('Promise result:', res))
         .catch(error => console.log(error));
 };

--- a/tests/switcher-functional.test.js
+++ b/tests/switcher-functional.test.js
@@ -193,6 +193,25 @@ describe('Integrated test - Switcher:', function () {
       assert.equal(spyPrepare.callCount, 2);
     });
 
+    it('should flush executions from a specific switcher key', async function () {
+      // given API responses
+      given(fetchStub, 0, { json: () => generateAuth('[auth_token]', 1), status: 200 });
+      given(fetchStub, 1, { json: () => generateResult(true), status: 200 }); // sync
+
+      Client.buildContext(contextSettings);
+      const switcher = Client.getSwitcher('FLAG_1').throttle(1000);
+      
+      // when
+      assert.isTrue(await switcher.isItOn());
+      let switcherExecutions = ExecutionLogger.getByKey('FLAG_1');
+      assert.equal(switcherExecutions.length, 1);
+
+      // test
+      switcher.flushExecutions();
+      switcherExecutions = ExecutionLogger.getByKey('FLAG_1');
+      assert.equal(switcherExecutions.length, 0);
+    });
+
     it('should not crash when async checkCriteria fails', async function () {
       this.timeout(5000);
 


### PR DESCRIPTION
This pull request adds a new capability to flush (clear) cached throttling results for a specific switcher, and documents this feature. It also introduces related utility and test code to ensure correct behavior. The most important changes are grouped below:

**New Feature: Flush Cached Throttling Results**

* Added a `flushExecutions()` method to the `Switcher` class, allowing users to clear cached execution results for a specific switcher. (`src/switcher.js`)
* Implemented the `clearByKey()` static method in `ExecutionLogger` to support clearing results by switcher key. (`src/lib/utils/executionLogger.js`)
* Updated the documentation to describe how to use the new flush functionality. (`README.md`)

**Testing and Validation**

* Added a functional test to verify that `flushExecutions()` removes cached executions for a switcher. (`tests/switcher-functional.test.js`)
* Minor update to the async call example in the playground test to use the correct method and clarify remote API requirements. (`tests/playground/index.js`)