### PR TITLE
feat: added resetInputs to clear strategy entries

### DIFF
--- a/src/switcher.d.ts
+++ b/src/switcher.d.ts
@@ -152,6 +152,11 @@ export class Switcher {
   restrictRelay(restrict: boolean): Switcher;
 
   /**
+   * Resets all strategy inputs
+   */
+  resetInputs(): Switcher;
+  
+  /**
    * Adds a strategy for validation
    */
   check(startegyType: string, input: string): Switcher;

--- a/src/switcherBuilder.js
+++ b/src/switcherBuilder.js
@@ -53,6 +53,11 @@ export class SwitcherBuilder {
     return this;
   }
 
+  resetInputs() {
+    this._input = undefined;
+    return this;
+  }
+
   check(startegyType, input) {
     if (!this._input) {
       this._input = [];

--- a/tests/switcher-client.test.js
+++ b/tests/switcher-client.test.js
@@ -197,6 +197,22 @@ describe('E2E test - Client local #1:', function () {
       'Group disabled');
   });
 
+  it('should clear strategy inputs', async function () {
+    // when
+    await switcher
+      .checkValue('Japan')
+      .checkNetwork('10.0.0.2')  
+      .prepare('FF2FOR2020');
+
+    assert.exists(switcher.input);
+    assert.isTrue(await switcher.isItOn());
+
+    // test
+    switcher.resetInputs();
+    assert.equal(switcher.input, undefined);
+    assert.isFalse(await switcher.isItOn());  
+  });
+
   it('should be valid - Local mode', async function () {
     this.timeout(3000);
 


### PR DESCRIPTION
This pull request introduces a new method to the `SwitcherBuilder` class to allow clearing of strategy inputs, along with an associated test to ensure correct behavior. The main goal is to provide a way to reset the internal input state and verify that this affects the switcher's operation as expected.

**Enhancements to input management and testing:**

* Added a new `resetInputs()` method to the `SwitcherBuilder` class, which clears the internal `_input` state and allows method chaining.
* Added an end-to-end test in `switcher-client.test.js` to verify that calling `resetInputs()` clears the input and changes the switcher's state accordingly.