### PR TITLE
fix: circuit breaker silent mode not working for in-mem snapshot

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,2 @@
-patreon: switcherapi
 ko_fi: petruki
 github: [petruki]

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -28,7 +28,7 @@ jobs:
           SWITCHER_API_KEY: ${{ secrets.SWITCHER_API_KEY }}
 
       - name: SonarCloud Scan
-        uses: sonarsource/sonarqube-scan-action@v7.0.0
+        uses: sonarsource/sonarqube-scan-action@v8.0.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         if: env.SONAR_TOKEN != ''

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -44,7 +44,7 @@ jobs:
           SWITCHER_API_KEY: ${{ secrets.SWITCHER_API_KEY }}
 
       - name: SonarCloud Scan
-        uses: sonarsource/sonarqube-scan-action@v7.0.0
+        uses: sonarsource/sonarqube-scan-action@v8.0.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         if: env.SONAR_TOKEN != ''

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ A JavaScript SDK for Switcher API
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=switcherapi_switcher-client-master&metric=alert_status)](https://sonarcloud.io/dashboard?id=switcherapi_switcher-client-master)
 [![npm version](https://badge.fury.io/js/switcher-client.svg)](https://badge.fury.io/js/switcher-client)
 [![install size](https://packagephobia.com/badge?p=switcher-client)](https://packagephobia.com/result?p=switcher-client)
-[![Known Vulnerabilities](https://snyk.io/test/github/switcherapi/switcher-client-js/badge.svg?targetFile=package.json)](https://snyk.io/test/github/switcherapi/switcher-client-js?targetFile=package.json)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Slack: Switcher-HQ](https://img.shields.io/badge/slack-@switcher/hq-blue.svg?logo=slack)](https://switcher-hq.slack.com/)
 

--- a/package.json
+++ b/package.json
@@ -31,19 +31,19 @@
     "src/"
   ],
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^8.57.1",
-    "@typescript-eslint/parser": "^8.57.1",
+    "@typescript-eslint/eslint-plugin": "^8.59.2",
+    "@typescript-eslint/parser": "^8.59.2",
     "c8": "^11.0.0",
     "chai": "^6.2.2",
     "env-cmd": "^11.0.0",
-    "eslint": "^10.1.0",
+    "eslint": "^10.3.0",
     "mocha": "^11.7.5",
     "mocha-sonarqube-reporter": "^1.0.2",
-    "sinon": "^21.0.3"
+    "sinon": "^22.0.0"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/switcherapi/switcher-client-js"
+    "url": "https://github.com/switcherapi/switcher-client-js.git"
   },
   "publishConfig": {
     "access": "public"

--- a/src/client.d.ts
+++ b/src/client.d.ts
@@ -115,7 +115,7 @@ export class Client {
   /**
    * Enable/Disable test mode.
    * 
-   * It prevents from watching Snapshots that may hold process
+   * It prevents subprocess to run during tests such as snapshot watcher
    */
   static testMode(testEnabled?: boolean): void;
 

--- a/src/client.js
+++ b/src/client.js
@@ -45,12 +45,12 @@ export class Client {
       logger: util.get(options?.logger, DEFAULT_LOGGER)
     });
 
+    // Initialize Auth
+    Auth.init(this.#context);
+
     if (options) {
       Client.#buildOptions(options);
     }
-
-    // Initialize Auth
-    Auth.init(this.#context);
   }
 
   static #buildOptions(options) {

--- a/src/lib/bypasser/index.js
+++ b/src/lib/bypasser/index.js
@@ -9,10 +9,7 @@ export default class Bypasser {
      * @param key 
      */
     static assume(key) {
-        const existentKey = this.searchBypassed(key);
-        if (existentKey) {
-            return existentKey;
-        }
+        Bypasser.forget(key);
 
         const keyBypassed = new Key(key);
         bypassedKeys.push(keyBypassed);


### PR DESCRIPTION
This pull request includes several updates focused on dependency management, workflow improvements, and minor codebase adjustments. The main highlights are dependency upgrades for development tools, updates to CI workflows, and some small code and configuration changes.

**Circuit Breaker - Silent Mode using in-memory Snapshot**
This was fixed by moving the remote module initialization before Context option during context build, which includes silent-mode settings.

**Dependency and Configuration Updates:**

* Upgraded development dependencies in `package.json`, including `@typescript-eslint/eslint-plugin`, `@typescript-eslint/parser`, `eslint`, and `sinon`, to their latest versions for improved linting and testing support. Also fixed the repository URL to use the `.git` suffix.
* Added `ignore-scripts=true` to `.npmrc` to prevent npm from running package lifecycle scripts, which can improve security in CI/CD environments.

**CI/CD Workflow Improvements:**

* Updated the SonarCloud scan GitHub Actions in both `.github/workflows/master.yml` and `.github/workflows/sonar.yml` to use `sonarsource/sonarqube-scan-action@v8.0.0` instead of `v7.0.0`, ensuring the latest features and fixes are used in code analysis. [[1]](diffhunk://#diff-38ee08b0d1916cb5b9d8a093e986366eaafd908bc1f516f4fced0033c155d842L31-R31) [[2]](diffhunk://#diff-9a1c250ec072fc76ad44435cd9462d5693ea81f304d650922d3c2792bef267c2L47-R47)

**Minor Code and Documentation Changes:**

* Changed the initialization order of `Auth.init` in the `Client` class constructor in `src/client.js` to ensure authentication is set up before options are built.
* Modified the `assume` method in `Bypasser` (`src/lib/bypasser/index.js`) to call `Bypasser.forget(key)` before creating a new bypassed key, ensuring old keys are removed before adding new ones.
* Removed the Snyk vulnerability badge from `README.md` and removed the `patreon` entry from `.github/FUNDING.yml` for documentation and funding clarity. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L14) [[2]](diffhunk://#diff-07985fdcade0e64d11482724879a644f07879ba61b8fb6c6119e1b1902b72ae4L1)